### PR TITLE
One try to solve the problem of the possible null values in the HookedMethod property of HookData.

### DIFF
--- a/src/NUnitFramework/framework/Attributes/ExecutionHookAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExecutionHookAttribute.cs
@@ -99,7 +99,19 @@ namespace NUnit.Framework
         /// <inheritdoc />
         public TestCommand Wrap(TestCommand command)
         {
-            return command is HookDelegatingTestCommand ? command : new HookDelegatingTestCommand(command);
+            if (command is not TestMethodCommand testMethodCommand)
+            {
+                throw new NUnitException($"{nameof(ExecutionHookAttribute)} " +
+                    $"can only be applied to {nameof(TestMethodCommand)}. " +
+                    $"Received: {command.GetType().Name}.");
+            }
+
+            if (command is HookDelegatingTestMethodCommand)
+            {
+                return command;
+            }
+
+            return new HookDelegatingTestMethodCommand(testMethodCommand);
         }
 
         /// <inheritdoc />

--- a/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/HookDelegatingTestMethodCommand.cs
@@ -5,26 +5,33 @@ using NUnit.Framework.Interfaces;
 
 namespace NUnit.Framework.Internal.Commands
 {
-    internal sealed class HookDelegatingTestCommand : DelegatingTestCommand
+    internal sealed class HookDelegatingTestMethodCommand : TestMethodCommand
     {
+        /// <summary>TODO: Documentation needed for field</summary>
+#pragma warning disable IDE1006
+        // ReSharper disable once InconsistentNaming
+        // Disregarding naming convention for back-compat
+        private readonly TestMethodCommand innerCommand;
+#pragma warning restore IDE1006
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="HookDelegatingTestCommand"/> class.
+        /// Initializes a new instance of the <see cref="HookDelegatingTestMethodCommand"/> class.
         /// </summary>
         /// <param name="innerCommand">The inner test command to delegate to.</param>
-        public HookDelegatingTestCommand(TestCommand innerCommand) : base(innerCommand)
+        public HookDelegatingTestMethodCommand(TestMethodCommand innerCommand) : base(innerCommand.TestMethod)
         {
+            this.innerCommand = innerCommand;
         }
 
         /// <summary>
-        /// Executes the test command within the provided context
+        /// Executes the test command within the provided context and
+        /// executes the hooks before and after the test method.
         /// </summary>
         /// <param name="context">The test execution context.</param>
         /// <returns>The result of the test execution.</returns>
         public override TestResult Execute(TestExecutionContext context)
         {
-            //Ask Manfred about proposal for handling this possible null value
-            IMethodInfo hookedMethodInfo = context.CurrentTest.Method;
-            // IMethodInfo hookedMethodInfo = context.CurrentTest.Method ?? new MethodWrapper(GetType(), nameof(Execute));
+            IMethodInfo hookedMethodInfo = innerCommand.TestMethod.Method;
 
             try
             {

--- a/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestMethodCommand.cs
@@ -27,6 +27,11 @@ namespace NUnit.Framework.Internal.Commands
         }
 
         /// <summary>
+        /// The test method.
+        /// </summary>
+        internal TestMethod TestMethod => _testMethod;
+
+        /// <summary>
         /// Runs the test, saving a TestResult in the execution context, as
         /// well as returning it. If the test has an expected result, it
         /// is asserts on that value. Since failed tests and errors throw

--- a/src/NUnitFramework/tests/ExecutionHooks/Execution/HookDelegatingTestMethodCommandTests.cs
+++ b/src/NUnitFramework/tests/ExecutionHooks/Execution/HookDelegatingTestMethodCommandTests.cs
@@ -2,18 +2,17 @@
 
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
-using NUnit.Framework.Tests.Attributes;
 
 namespace NUnit.Framework.Tests.ExecutionHooks.Execution
 {
-    internal class HookDelegatingTestCommandTests
+    internal class HookDelegatingTestMethodCommandTests
     {
         private class Prover
         {
             public bool WasInsideExecute { get; set; }
         }
 
-        private class MockedTestCommand(Test test, Prover prover) : TestCommand(test)
+        private class MockedTestMethodCommand(TestMethod test, Prover prover) : TestMethodCommand(test)
         {
             public override TestResult Execute(TestExecutionContext context)
             {
@@ -26,12 +25,13 @@ namespace NUnit.Framework.Tests.ExecutionHooks.Execution
         public void InnerCommandIsAlwaysExecuted()
         {
             var prover = new Prover();
-            var mockedTestCommand = new MockedTestCommand(new TestDummy(), prover);
-            var hookDelegatingTestCommandCommand = new HookDelegatingTestCommand(mockedTestCommand);
+            var testMethodDummy = new TestMethod(new MethodWrapper(GetType(), nameof(InnerCommandIsAlwaysExecuted)));
+            var mockedTestCommand = new MockedTestMethodCommand(testMethodDummy, prover);
+            var hookDelegatingTestMethodCommand = new HookDelegatingTestMethodCommand(mockedTestCommand);
 
             Assert.That(prover.WasInsideExecute, Is.False);
 
-            hookDelegatingTestCommandCommand.Execute(TestExecutionContext.CurrentContext);
+            hookDelegatingTestMethodCommand.Execute(TestExecutionContext.CurrentContext);
 
             Assert.That(prover.WasInsideExecute, Is.True);
         }


### PR DESCRIPTION
Introduced new command that enforces MethodCommands instead of normal TestCommands and made all necessary adaptations to embed them into the existing source.